### PR TITLE
下層ページ直接アクセス時の404への対応

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,10 @@
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404</title>
+    <script>
+        sessionStorage.setItem('path', location.pathname);
+        location.replace('./');
+    </script>
+</head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,1 +1,19 @@
-<!doctype html><html lang="ja"><head><meta charset="UTF-8"><title>集-tsudoi-</title><script defer="defer" src="/tsudoi-hp/static/js/main.9ef7d280.js"></script><link href="/tsudoi-hp/static/css/main.d440b10b.css" rel="stylesheet"></head><body><div id="root"></div></body></html>
+<!doctype html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <title>集-tsudoi-</title>
+        <script defer="defer" src="/tsudoi-hp/static/js/main.9ef7d280.js"></script>
+        <link href="/tsudoi-hp/static/css/main.d440b10b.css" rel="stylesheet">
+        <script>
+            const path = sessionStorage.getItem('path');
+            console.log(path);
+            if (path && path !== '/tsudoi-hp/') {
+              sessionStorage.removeItem('path');
+              window.history.replaceState(null, null, 'https://akanematsubara.github.io' + path);
+            }
+        </script>
+    </head>
+    <body><div id="root"></div>
+    </body>
+</html>


### PR DESCRIPTION
### ルートディレクトリに404.htmlを新規作成

現在のパスを取得した上で、index.htmlへリダイレクトする
```
    <script>
        sessionStorage.setItem('path', location.pathname);
        location.replace('./');
    </script>
```

### index.html内に下層ページへのリダイレクト処理を追加

404.htmlで取得したパスに対して
　パスがトップページを示している場合　→　何もしない(=index.htmlが表示)
　パスがトップページ以外(=下層のページ)を示している場合　→　replaceStateで下層ページへ遷移させる
```
        <script>
            const path = sessionStorage.getItem('path');
            console.log(path);
            if (path && path !== '/tsudoi-hp/') {
              sessionStorage.removeItem('path');
              window.history.replaceState(null, null, 'https://akanematsubara.github.io' + path);
            }
        </script>
```

- 参照
[Location](https://developer.mozilla.org/ja/docs/Web/API/Location)
[History: replaceState() メソッド](https://developer.mozilla.org/ja/docs/Web/API/History/replaceState)


